### PR TITLE
Add _get_many support

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,8 +1,6 @@
 * Compression support: when we sent a compressed message ActiveMQ seems to not
   being sending back the compression header, so Kombu doesn't know how to
   handle the message.
-* Add support for _get_many transport method, so we can read all queues at the
-  same time.
 * Do we need a queue iterator sentinel?? So we can notify the queue is empty
   and probably set QoS to not able to consume.
 * STOMP transaction support

--- a/kombu_stomp/stomp.py
+++ b/kombu_stomp/stomp.py
@@ -43,7 +43,10 @@ class MessageListener(listener.ConnectionListener):
         # properties is a dictionary and we need evaluate it
         message['properties'] = ast.literal_eval(message['properties'])
         message['body'] = body
-        return message, msg_id
+        return (
+            (message, msg_id),
+            self.queue_from_destination(headers['destination']),
+        )
 
     def iterator(self, timeout):
         """Return a Python generator consuming received messages.
@@ -60,6 +63,10 @@ class MessageListener(listener.ConnectionListener):
         while True:
             # Block only if get got a timeout
             yield self.q.get(block=bool(timeout), timeout=timeout)
+
+    def queue_from_destination(self, destination):
+        """Get the queue name from a destination header value."""
+        return destination.split('/queue/')[1]
 
 
 class Connection(stomp.Connection10):

--- a/kombu_stomp/transport.py
+++ b/kombu_stomp/transport.py
@@ -53,11 +53,11 @@ class Channel(virtual.Channel):
         super(Channel, self).__init__(*args, **kwargs)
         self._stomp_conn = None
 
-    def _get(self, queue):
-        """Get next messesage from `queue`."""
+    def _get_many(self, queue, timeout=None):
+        """Get next messesage from current active queues."""
         with self.conn_or_acquire() as conn:
             # FIXME(rafaduran): inappropriate intimacy code smell
-            return next(conn.message_listener.iterator(timeout=None))
+            return next(conn.message_listener.iterator(timeout=timeout))
 
     def _put(self, queue, message, **kwargs):
         with self.conn_or_acquire() as conn:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = kombu-stomp
-version = 0.0.0.dev0
+version = 0.0.0.dev1
 author = NTTE-AM OSS
 author-email = am.oss@ntt.eu
 summary =

--- a/tests/test_stomp.py
+++ b/tests/test_stomp.py
@@ -55,7 +55,7 @@ class MessageListenerTests(ListenerTestCase):
 
     def test_to_kombu_message__return_message_as_dict(self):
         self.assertDictEqual(
-            self.listener.to_kombu_message(self.headers, self.body)[0],
+            self.listener.to_kombu_message(self.headers, self.body)[0][0],
             {
                 'content-encoding': 'utf-8',
                 'content-type': 'application/json',
@@ -75,8 +75,14 @@ class MessageListenerTests(ListenerTestCase):
 
     def test_to_kombu_message__return_message_id(self):
         self.assertEqual(
-            self.listener.to_kombu_message(self.headers, self.body)[1],
+            self.listener.to_kombu_message(self.headers, self.body)[0][1],
             'ID:services-55311-1412009732901-5:6816:-1:1:1',
+        )
+
+    def test_to_kombu_message__return_queue_name(self):
+        self.assertEqual(
+            self.listener.to_kombu_message(self.headers, self.body)[1],
+            'simple_queue',
         )
 
     def test_iterator(self):
@@ -95,6 +101,12 @@ class MessageListenerTests(ListenerTestCase):
         it = self.listener.iterator(None)
         next(it)
         self.queue.get.assert_called_once_with(block=False, timeout=None)
+
+    def test_queue_from_destination(self):
+        self.assertEqual(
+            self.listener.queue_from_destination(self.headers['destination']),
+            'simple_queue',
+        )
 
 
 class ConnectionTests(unittest.TestCase):

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -141,12 +141,12 @@ class ChannelConnectionTests(unittest.TestCase):
 
     @mock.patch('kombu_stomp.transport.Channel.conn_or_acquire',
                 new_callable=mock.MagicMock)  # for the context manager
-    def test_get(self, conn_or_acquire):
+    def test_get_many(self, conn_or_acquire):
         stomp_conn = conn_or_acquire.return_value.__enter__.return_value
         iterator = stomp_conn.message_listener.iterator
         iterator.return_value = iter([1])
 
-        self.assertEqual(self.channel._get(self.queue), 1)
+        self.assertEqual(self.channel._get_many([self.queue]), 1)
         iterator.assert_called_once_with(timeout=None)
 
     @mock.patch('kombu_stomp.transport.Channel.conn_or_acquire',


### PR DESCRIPTION
Since we can get messages from many queues at the same time, we don't
need Kombu to check each one individually.
