### PR TITLE
Add queue_prefix_name transport option support

### DIFF
--- a/kombu_stomp/stomp.py
+++ b/kombu_stomp/stomp.py
@@ -9,11 +9,12 @@ from stomp import listener
 
 class MessageListener(listener.ConnectionListener):
     """stomp.py listener used by ``kombu-stomp``"""
-    def __init__(self, q=None):
+    def __init__(self, prefix='', q=None):
         if not q:
             q = queue.Queue()
 
         self.q = q
+        self.prefix = prefix
 
     def on_message(self, headers, body):
         """Received message hook.
@@ -67,12 +68,12 @@ class MessageListener(listener.ConnectionListener):
 
     def queue_from_destination(self, destination):
         """Get the queue name from a destination header value."""
-        return destination.split('/queue/')[1]
+        return destination.split('/queue/{0}'.format(self.prefix))[1]
 
 
 class Connection(stomp.Connection10):
     """Connection object used by ``kombu-stomp``"""
-    def __init__(self, *args, **kwargs):
+    def __init__(self, prefix='', *args, **kwargs):
         super(Connection, self).__init__(*args, **kwargs)
-        self.message_listener = MessageListener()
+        self.message_listener = MessageListener(prefix=prefix)
         self.set_listener('message_listener', self.message_listener)

--- a/tests/test_stomp.py
+++ b/tests/test_stomp.py
@@ -108,14 +108,21 @@ class MessageListenerTests(ListenerTestCase):
             'simple_queue',
         )
 
+    def test_queue_from_destination__prefix(self):
+        self.listener.prefix = 'prefix.'
+        self.assertEqual(
+            self.listener.queue_from_destination('/queue/prefix.simple_queue'),
+            'simple_queue',
+        )
+
 
 class ConnectionTests(unittest.TestCase):
 
     @mock.patch('kombu_stomp.stomp.MessageListener')
-    def test_message_lisetner_its_set_on_init(self, Listener):
+    def test_message_listener_its_set_on_init(self, Listener):
         self.conn = stomp.Connection()
         self.assertEqual(
             self.conn.get_listener('message_listener'),
             Listener.return_value,
         )
-        Listener.assert_called_once_with()
+        Listener.assert_called_once_with(prefix='')

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -220,3 +220,13 @@ class ChannelConnectionTests(unittest.TestCase):
     def test_close__close_closed_connection(self, Connection, close):
         Connection.close.side_effect = exc.NotConnectedException
         self.channel.close()  # just check this doesn't trigger exceptions
+
+    def test_queue_destination__prefix(self):
+        self.connection.client.transport_options = {
+            'queue_name_prefix': 'prefix.',
+        }
+
+        self.assertEqual(
+            self.channel.queue_destination(self.queue),
+            '/queue/prefix.queue',
+        )


### PR DESCRIPTION
In some situations a prefix can help a lot dealing with ActiveMQ
permissions model, so you can add a prefix to the queue names and an
authorization entry just for that prefix.
