### PR TITLE
Ignore timeout when obtaining messages from queues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,4 +20,6 @@ Currently we offer very limited support:
 
 * There is no transport options support but the host, port and credentials.
 
+* There is no support for timeout when consuming queues.
+
 .. _`Read the docs`: http://kombu-stomp.readthedocs.org/en/latest/

--- a/kombu_stomp/stomp.py
+++ b/kombu_stomp/stomp.py
@@ -50,21 +50,18 @@ class MessageListener(listener.ConnectionListener):
             self.queue_from_destination(headers['destination']),
         )
 
-    def iterator(self, timeout):
+    def iterator(self):
         """Return a Python generator consuming received messages.
 
         If we try to consume a message and there is no messages remaining, then
         an exception will be raised.
 
-        :arg int timeout: Time to wait for message in seconds, a falsy value if
-            we shouldn't block for incoming messages.
         :yields dict: A dictionary representing the message in a Kombu
             compatible format.
         :raises: :py:exc:`Queue.Empty` When there is no message to be consumed.
         """
         while True:
-            # Block only if get got a timeout
-            yield self.q.get(block=bool(timeout), timeout=timeout)
+            yield self.q.get_nowait()
 
     def queue_from_destination(self, destination):
         """Get the queue name from a destination header value."""

--- a/kombu_stomp/transport.py
+++ b/kombu_stomp/transport.py
@@ -58,13 +58,17 @@ class Channel(virtual.Channel):
         self._subscriptions = set()
 
     def _get_many(self, queue, timeout=None):
-        """Get next messesage from current active queues."""
+        """Get next messesage from current active queues.
+
+        Note that we are ignoring any timeout due to performance
+        issues.
+        """
         with self.conn_or_acquire() as conn:
             for q in queue:
                 self.subscribe(conn, q)
 
             # FIXME(rafaduran): inappropriate intimacy code smell
-            return next(conn.message_listener.iterator(timeout=timeout))
+            return next(conn.message_listener.iterator())
 
     def _put(self, queue, message, **kwargs):
         with self.conn_or_acquire() as conn:

--- a/tests/test_stomp.py
+++ b/tests/test_stomp.py
@@ -86,21 +86,15 @@ class MessageListenerTests(ListenerTestCase):
         )
 
     def test_iterator(self):
-        self.queue.get.side_effect = (1, 3)
-        it = self.listener.iterator(timeout=5)
+        self.queue.get_nowait.side_effect = (1, 3)
+        it = self.listener.iterator()
         self.assertEqual(1, next(it))
         self.assertEqual(3, next(it))
 
     def test_iterator__empty(self):
         self.listener.q = queue.Queue()
-        it = self.listener.iterator(timeout=None)
+        it = self.listener.iterator()
         self.assertRaises(queue.Empty, lambda: next(it))
-
-    def test_iterator__non_blocking(self):
-        self.queue.get.side_effect = [1]
-        it = self.listener.iterator(None)
-        next(it)
-        self.queue.get.assert_called_once_with(block=False, timeout=None)
 
     def test_queue_from_destination(self):
         self.assertEqual(

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -158,7 +158,7 @@ class ChannelConnectionTests(unittest.TestCase):
         iterator.return_value = iter([1])
 
         self.assertEqual(self.channel._get_many([self.queue]), 1)
-        iterator.assert_called_once_with(timeout=None)
+        iterator.assert_called_once_with()
 
     @mock.patch('kombu_stomp.transport.Channel.conn_or_acquire',
                 new_callable=mock.MagicMock)  # for the context manager


### PR DESCRIPTION
We have been forced to ignore timeouts since it led to performance
issues working with Celery.

If some kind of timeout is needed, the modified methods in this
commit should be reviewed.